### PR TITLE
Updating twitter gem, we were using a prelease version

### DIFF
--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency 'logstash', '>= 1.4.0', '< 2.0.0'
 
-  s.add_runtime_dependency 'twitter', ['5.0.0.rc.1']
+  s.add_runtime_dependency 'twitter', ['5.12.0']
 
 end
 

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -1,1 +1,5 @@
 require 'spec_helper'
+require 'logstash/inputs/twitter'
+
+describe LogStash::Inputs::Twitter do
+end


### PR DESCRIPTION
This PR fix the build problem for the twitter input format.
the gem http-0.6.0.pre is trying to use a new version of the http_parser.

Since we were using a pre release version of the twitter gem,
I think it make sense to update it to a stable/official version.

You can look at the changelog: https://github.com/sferik/twitter/blob/master/CHANGELOG.md

```
Installing rumbster 1.1.1
Installing maven-tools 1.0.5
Installing ruby-maven 3.1.1.0.8
Using logstash 2.0.0.dev from source at /home/jenkins/workspace/logstash_input_twitter_commit/logstash
Your bundle is complete!
Gems in the group development were not installed.
It was installed into ./vendor/bundle
validating ../logstash-input-twitter/logstash-input-twitter-0.1.0.gem >= 0
Valid logstash plugin. Continuing...
Gem::ImpossibleDependenciesError: http-0.6.0.pre requires http_parser.rb (~> 0.6.0) but it conflicted:
  Activated http_parser.rb-0.6.0 instead of (~> 0.5.0) via:
    twitter-5.0.0.rc.1, logstash-input-twitter-0.1.0

```
