### PR TITLE
Catch Twitter::NullObject instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+1.0.1
+  * Handle tweets with a null 'in-reply-to' without crashing. This is a temporary fix till JrJackson is updated.

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -106,6 +106,8 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
             end
           end
 
+          # Work around bugs in JrJackson. The standard serializer won't work till we upgrade
+          event["in-reply-to"] = nil if event["in-reply-to"].is_a?(Twitter::NullObject)
           decorate(event)
           queue << event
         end

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-twitter'
-  s.version         = '1.0.0'
+  s.version         = '1.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the twitter streaming api."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -25,4 +25,3 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'logstash-devutils'
 end
-


### PR DESCRIPTION
This is a quick fix for release today. Since specs for this plugin are sorely lacking I guerrilla tested this by temporarily inserting the following snippet below the added code, testing it against the real world twitter API: 

```ruby
          if event["in-reply-to"].is_a?(Twitter::NullObject)
            binding.pry
          end
```

it correctly caught the issue.