### PR TITLE
Proxy support for connecting to twitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+  - Upgraded the twitter gem to the last version available, 5.15.0
+  - Add proxy support.
+
 ## 2.1.0
   - Add an option to fetch data from the sample endpoint.
   - Add hashtags, symbols and user_mentions as data for the non extended tweet event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.2.0
   - Upgraded the twitter gem to the last version available, 5.15.0
-  - Add proxy support.
+  - Add proxy support, Fixes #7.
 
 ## 2.1.0
   - Add an option to fetch data from the sample endpoint.

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -1,0 +1,76 @@
+# encoding: utf-8
+require 'twitter/streaming/connection'
+require 'twitter/streaming/response'
+require 'twitter/streaming/message_parser'
+
+module LogStash
+  module Inputs
+    class TwitterPatches
+
+      def self.patch
+        verify_version
+        patch_json
+        patch_connection_stream
+        patch_request
+      end
+
+      private
+
+      def self.verify_version
+        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "5.15.0"
+      end
+
+      def self.patch_connection_stream
+        ::Twitter::Streaming::Connection.class_eval do
+          def stream(request, response)
+            client_context = OpenSSL::SSL::SSLContext.new
+            client         = @tcp_socket_class.new(Resolv.getaddress(request.socket_host), request.socket_port)
+            ssl_client     = @ssl_socket_class.new(client, client_context)
+
+            ssl_client.connect
+            request.stream(ssl_client)
+            while body = ssl_client.readpartial(1024) # rubocop:disable AssignmentInCondition
+              response << body
+            end
+          end
+
+          def normalized_port(scheme)
+            HTTP::URI.port_mapping[scheme]
+          end
+        end
+      end
+
+      def self.patch_request
+        ::Twitter::Streaming::Client.class_eval do
+          def request(method, uri, params)
+            before_request.call
+            headers = ::Twitter::Headers.new(self, method, uri, params).request_headers
+            request = ::HTTP::Request.new(method, uri + '?' + to_url_params(params), headers, proxy)
+            response = ::Twitter::Streaming::Response.new do |data|
+              if item = ::Twitter::Streaming::MessageParser.parse(data) # rubocop:disable AssignmentInCondition
+                yield(item)
+              end
+            end
+            @connection.stream(request, response)
+          end
+        end
+      end
+
+      def self.patch_json
+        ::Twitter::Streaming::Response.module_eval do
+          def on_body(data)
+            @tokenizer.extract(data).each do |line|
+              next if line.empty?
+              begin
+                @block.call(LogStash::Json.load(line, :symbolize_keys => true))
+              rescue LogStash::Json::ParserError
+                # silently ignore json parsing errors
+              end
+            end
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-twitter'
-  s.version         = '2.1.0'
+  s.version         = '2.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the twitter streaming api."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
   s.add_runtime_dependency 'twitter', '5.15.0'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'
-  s.add_runtime_dependency 'concurrent-ruby', '0.9.1'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -21,8 +21,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency 'twitter', '5.14.0'
+  s.add_runtime_dependency 'twitter', '5.15.0'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'
+  s.add_runtime_dependency 'concurrent-ruby', '0.9.1'
 
   s.add_development_dependency 'logstash-devutils'
   s.add_development_dependency 'logstash-codec-plain'

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -188,6 +188,5 @@ describe LogStash::Inputs::Twitter do
       end
 
     end
-
   end
 end

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -71,5 +71,36 @@ describe LogStash::Inputs::Twitter do
       end
 
     end
+
+    context "when using a proxy" do
+      let(:config) do
+        <<-CONFIG
+       input {
+         twitter {
+            consumer_key => '#{ENV['TWITTER_CONSUMER_KEY']}'
+            consumer_secret => '#{ENV['TWITTER_CONSUMER_SECRET']}'
+            keywords => [ "London", "Barcelona" ]
+            oauth_token => '#{ENV['TWITTER_OAUTH_TOKEN']}'
+            oauth_token_secret => '#{ENV['TWITTER_OAUTH_TOKEN_SECRET']}'
+            full_tweet => true
+            use_proxy => true
+            proxy_address => '127.0.0.1'
+            proxy_port => 8123
+        }
+      }
+        CONFIG
+      end
+
+      let(:events) do
+        input(config) do |pipeline, queue|
+          3.times.collect { queue.pop }
+        end
+      end
+
+      it "receive a list of events from the twitter stream" do
+        expect(events.count).to eq(3)
+      end
+    end
   end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,6 @@ class MockClient
   def filter(options)
     loop { yield }
   end
-
   alias_method :sample, :filter
 end
 


### PR DESCRIPTION
It Fixes #7 by patching the last version of the twitter gem to work properly with proxies. As soon as there is a new twitter gem released, proxy support should be fix, just opened an issue upstream https://github.com/sferik/twitter/issues/741 to gather feedback to wrap up everything.

