### PR TITLE
Plugin improvement and cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 Gemfile.lock
 .bundle
 vendor
+*.sh

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -56,13 +56,18 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   # return statuses for in the stream.
   # See https://dev.twitter.com/streaming/overview/request-parameters#follow
   # for more details.
-  config :follows, :validate => :string
+  config :follows, :validate => :array
 
   # A comma-separated list of longitude,latitude pairs specifying a set
   # of bounding boxes to filter Tweets by.
   # See https://dev.twitter.com/streaming/overview/request-parameters#locations
   # for more details
   config :locations, :validate => :string
+
+  # A list of BCP 47 language identifiers corresponding to any of the languages listed
+  # on Twitter’s advanced search page will only return Tweets that have been detected 
+  # as being written in the specified languages
+  config :languages, :validate => :array
 
   # Returns a small random sample of all public statuses. The Tweets returned
   # by the default access level are the same, so if two different clients connect
@@ -178,8 +183,10 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
 
   def build_options
     options = {}
-    options[:track]     = @keywords.join(",") if @keywords && @keywords.length > 0
-    options[:locations] = @locations          if @locations && @location.length > 0
+    options[:track]     = @keywords.join(",")  if @keywords && @keywords.length > 0
+    options[:locations] = @locations           if @locations && @location.length > 0
+    options[:language]  = @languages.join(",") if @languages && @languages.length > 0
+
     if @follows && @follows.length > 0
       options[:follow]    = @follows.split(",").map do |username|
         (  username.to_i == 0 ? find_userid(username) : username )

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -209,7 +209,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
 
     if @follows && @follows.length > 0
       build_options[:follow]    = @follows.map do |username|
-        (  username.to_i == 0 ? find_userid(username) : username )
+        (  !is_number?(username) ? find_userid(username) : username )
       end.join(",")
     end
     build_options
@@ -219,4 +219,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     @rest_client.user(:user => username)
   end
 
+  def is_number?(string)
+    /^(\d+)$/.match(string) ? true : false
+  end
 end # class LogStash::Inputs::Twitter

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -47,7 +47,13 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   config :oauth_token_secret, :validate => :password, :required => true
 
   # Any keywords to track in the twitter stream
-  config :keywords, :validate => :array, :required => true
+  config :keywords, :validate => :array, :default => []
+
+  # Any follows to track in the twitter stream (follow id)
+  config :follows, :validate => :array, :default => []
+
+  # Any locations to track in the twitter stream
+  config :locations, :validate => :array, :default => []
 
   # Record full tweet object as given to us by the Twitter stream api.
   config :full_tweet, :validate => :boolean, :default => false
@@ -84,9 +90,12 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
 
   public
   def run(queue)
-    @logger.info("Starting twitter tracking", :keywords => @keywords)
+    @logger.info("Starting twitter tracking", :keywords => @keywords,
+                                              :follow => @follows,
+                                              :location => @locations)
     begin
-      @client.filter(:track => @keywords.join(",")) do |tweet|
+      @client.filter(:track => @keywords.join(","), :follow => @follows.join(","),
+                     :location => @locations.join(",")) do |tweet|
         return if stop?
         if tweet.is_a?(Twitter::Tweet)
           event = from_tweet(tweet)

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -77,6 +77,10 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   def register
     require "twitter"
 
+    if !@use_samples && ( @keywords.nil? && @follows.nil? && @locations.nil? )
+      raise LogStash::ConfigurationError.new("At least one parameter (follows, locations or keywords) must be specified.")
+    end
+
     # monkey patch twitter gem to ignore json parsing error.
     # at the same time, use our own json parser
     # this has been tested with a specific gem version, raise if not the same

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -65,7 +65,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     # monkey patch twitter gem to ignore json parsing error.
     # at the same time, use our own json parser
     # this has been tested with a specific gem version, raise if not the same
-    raise("Incompatible Twitter gem version and the LogStash::Json.load") unless Twitter::Version.to_s == "5.12.0"
+    raise("Incompatible Twitter gem version and the LogStash::Json.load") unless Twitter::Version.to_s == "5.14.0"
 
     Twitter::Streaming::Response.module_eval do
       def on_body(data)

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -110,7 +110,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   end
 
   def run(queue)
-    @logger.info("Starting twitter tracking", twitter_options)
+    @logger.info("Starting twitter tracking", twitter_options.clone) # need to pass a clone as it modify this var otherwise
     begin
       if @use_samples
         @stream_client.sample do |tweet|
@@ -138,7 +138,6 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   end
 
   def twitter_options
-    @twitter_options.delete(:level) # This is added by the logger when you pass the full hash as params
     @twitter_options
   end
 
@@ -203,19 +202,19 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
 
   def build_options
     build_options = {}
-    build_options[:track]     = @keywords.join(",")  if @keywords && @keywords.length > 0
-    build_options[:locations] = @locations           if @locations && @locations.length > 0
-    build_options[:language]  = @languages.join(",") if @languages && @languages.length > 0
+    build_options[:track]     = @keywords.join(",")  if @keywords  && !@keywords.empty?
+    build_options[:locations] = @locations           if @locations && !@locations.empty?
+    build_options[:language]  = @languages.join(",") if @languages && !@languages.empty?
 
     if @follows && @follows.length > 0
       build_options[:follow]    = @follows.map do |username|
-        (  !is_number?(username) ? find_userid(username) : username )
+        (  !is_number?(username) ? find_user(username) : username )
       end.join(",")
     end
     build_options
   end
 
-  def find_userid(username)
+  def find_user(username)
     @rest_client.user(:user => username)
   end
 

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -95,20 +95,8 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
       end
     end
 
-    @rest_client = Twitter::REST::Client.new do |c|
-      c.consumer_key = @consumer_key
-      c.consumer_secret = @consumer_secret.value
-      c.access_token = @oauth_token
-      c.access_token_secret = @oauth_token_secret.value
-    end
-
-    @stream_client = Twitter::Streaming::Client.new do |c|
-      c.consumer_key = @consumer_key
-      c.consumer_secret = @consumer_secret.value
-      c.access_token = @oauth_token
-      c.access_token_secret = @oauth_token_secret.value
-    end
-
+    @rest_client    = Twitter::REST::Client.new { |c|  configure(c) }
+    @stream_client  = Twitter::Streaming::Client.new { |c|  configure(c) }
     @filter_options = build_options
   end
 
@@ -175,6 +163,13 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     event["in-reply-to"] = nil if event["in-reply-to"].is_a?(Twitter::NullObject)
 
     event
+  end
+
+  def configure(c)
+    c.consumer_key = @consumer_key
+    c.consumer_secret = @consumer_secret.value
+    c.access_token = @oauth_token
+    c.access_token_secret = @oauth_token_secret.value
   end
 
   def options

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 2.0.0.beta2", "< 3.0.0"
-  s.add_runtime_dependency 'twitter', ['5.12.0']
+  s.add_runtime_dependency 'twitter', '5.14.0'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'
 
   s.add_development_dependency 'logstash-devutils'

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -2,14 +2,6 @@ require_relative "../spec_helper"
 
 describe LogStash::Inputs::Twitter do
 
-  let(:mock_client) { MockClient.new }
-
-  before :each do
-    allow(Twitter::Streaming::Client).to receive(:new).and_return(mock_client)
-  end
-
-  let(:input) { LogStash::Plugin.lookup("input", "twitter").new(config) }
-
   let(:config) do
     {
       'consumer_key' => 'foo',
@@ -20,14 +12,12 @@ describe LogStash::Inputs::Twitter do
     }
   end
 
-  context "when told to shutdown" do
-    it_behaves_like "an interruptible input plugin"
-  end
+  let(:plugin) { LogStash::Inputs::Twitter.new(config) }
 
-  context "registration" do
+  describe "registration" do
 
     it "not raise error" do
-      expect {input.register}.to_not raise_error
+      expect {plugin.register}.to_not raise_error
     end
 
     context "with no required configuration fields" do
@@ -41,12 +31,22 @@ describe LogStash::Inputs::Twitter do
       end
 
       it "raise an error if no required fields are specified" do
-        expect {input.register}.to raise_error(LogStash::ConfigurationError)
+        expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
       end
     end
   end
 
-  context "stream filter" do
+  describe "when told to shutdown" do
+    before(:each) do
+      allow(Twitter::Streaming::Client).to receive(:new).and_return(MockClient.new)
+    end
+    it_behaves_like "an interruptible input plugin"
+  end
+
+  describe "fetching from sample" do
+
+    let(:input) { LogStash::Inputs::Twitter.new(config) }
+    let(:queue) { Queue.new }
 
     let(:config) do
       {
@@ -54,77 +54,140 @@ describe LogStash::Inputs::Twitter do
         'consumer_secret' => 'foo',
         'oauth_token' => 'foo',
         'oauth_token_secret' => 'foo',
-        'keywords' => ['foo'],
-        'languages' => ['en', 'fr'],
-        'locations' => "1234,2343",
-        'follows' => [ '1234', '4321' ]
+        'use_samples' => true
       }
     end
 
+    let(:stream_client)       { double("stream-client") }
+
     before(:each) do
       input.register
+      input.set_stream_client(stream_client)
     end
 
-    let(:options) { input.twitter_options }
-
-    it "include the track filter in options" do
-      expect(options).to include(:track=>"foo")
+    it "uses the sample endpoint" do
+      expect(stream_client).to receive(:sample).once
+      run_input_with(input, queue)
     end
-
-    it "include the language filter in options" do
-      expect(options).to include(:language=>"en,fr")
-    end
-
-    it "include the locations filter in options" do
-      expect(options).to include(:locations=>"1234,2343")
-    end
-
-     it "include the follows filter in options" do
-      expect(options).to include(:follow=>"1234,4321")
-    end
-
-     describe "run" do
-
-       let(:queue) { Queue.new }
-
-       before(:each) do
-         input.register
-       end
-
-       let(:options) do
-         {:track=>"foo", :locations=>"1234,2343", :language=>"en,fr", :follow=>"1234,4321"}
-       end
-
-       it "using the filter endpoint" do
-         expect(mock_client).to receive(:filter).with(options).once
-         Thread.new do
-           input.run(queue)
-         end
-         sleep 0.1
-       end
-
-       context "#sample" do
-         let(:config) do
-           {
-             'consumer_key' => 'foo',
-             'consumer_secret' => 'foo',
-             'oauth_token' => 'foo',
-             'oauth_token_secret' => 'foo',
-             'use_samples' => true
-           }
-         end
-
-         it "using the sample endpoint" do
-           expect(mock_client).to receive(:sample).once
-           Thread.new do
-             input.run(queue)
-           end
-           sleep 0.1
-         end
-
-       end
-     end
 
   end
 
+  describe "stream filter" do
+
+    describe "options parsing" do
+
+      let(:plugin) { LogStash::Inputs::Twitter.new(config) }
+
+      let(:config) do
+        {
+          'consumer_key' => 'foo',
+          'consumer_secret' => 'foo',
+          'oauth_token' => 'foo',
+          'oauth_token_secret' => 'foo',
+          'keywords' => ['foo'],
+          'languages' => ['en', 'fr'],
+          'locations' => "1234,2343",
+          'follows' => [ '1234', '4321' ]
+        }
+      end
+
+      before(:each) do
+        plugin.register
+      end
+
+      let(:options) { plugin.twitter_options }
+
+      it "include the track filter in options" do
+        expect(options).to include(:track=>"foo")
+      end
+
+      it "include the language filter in options" do
+        expect(options).to include(:language=>"en,fr")
+      end
+
+      it "include the locations filter in options" do
+        expect(options).to include(:locations=>"1234,2343")
+      end
+
+      it "include the follows filter in options" do
+        expect(options).to include(:follow=>"1234,4321")
+      end
+    end
+
+    describe "run" do
+
+      let(:input) { LogStash::Inputs::Twitter.new(config) }
+
+      let(:queue) { Queue.new }
+
+      let(:stream_client)       { double("stream-client") }
+
+      let(:options) do
+        {:track=>"foo,bar"}
+      end
+
+      before(:each) do
+        input.register
+        input.set_stream_client(stream_client)
+      end
+
+      it "using the filter endpoint" do
+        expect(stream_client).to receive(:filter).with(options).once
+        run_input_with(input, queue)
+      end
+
+      context "when not filtering retweets" do
+
+        let(:tweet) { Twitter::Tweet.new(id: 1) }
+
+        let(:config) do
+          {
+            'consumer_key' => 'foo',
+            'consumer_secret' => 'foo',
+            'oauth_token' => 'foo',
+            'oauth_token_secret' => 'foo',
+            'keywords' => ['foo'],
+            'languages' => ['en', 'fr'],
+            'locations' => "1234,2343",
+            'ignore_retweets' => false
+          }
+        end
+
+        it "not exclude retweets" do
+          allow(tweet).to receive(:retweet?).and_return(true)
+          expect(input).to receive(:from_tweet).with(tweet)
+          expect(stream_client).to receive(:filter).at_least(:once).and_yield(tweet)
+          expect(queue).to receive(:<<)
+          run_input_with(input, queue)
+        end
+      end
+
+      context "when filtering retweets" do
+
+        let(:tweet) { Twitter::Tweet.new(id: 1) }
+
+        let(:config) do
+          {
+            'consumer_key' => 'foo',
+            'consumer_secret' => 'foo',
+            'oauth_token' => 'foo',
+            'oauth_token_secret' => 'foo',
+            'keywords' => ['foo'],
+            'languages' => ['en', 'fr'],
+            'locations' => "1234,2343",
+            'ignore_retweets' => true
+          }
+        end
+
+        it "exclude retweets" do
+          allow(tweet).to receive(:retweet?).and_return(true)
+          expect(stream_client).to receive(:filter).at_least(:once).and_yield(tweet)
+          expect(queue).not_to receive(:<<)
+          run_input_with(input, queue)
+        end
+      end
+
+    end
+
+  end
 end

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -1,12 +1,4 @@
-require "logstash/devutils/rspec/spec_helper"
-require 'logstash/inputs/twitter'
-require 'twitter'
-
-class MockClient
-  def filter(options)
-    loop { yield }
-  end
-end
+require_relative "../spec_helper"
 
 describe LogStash::Inputs::Twitter do
   context "when told to shutdown" do
@@ -14,16 +6,24 @@ describe LogStash::Inputs::Twitter do
       allow(Twitter::Streaming::Client).to receive(:new).and_return(MockClient.new)
     end
 
-    it_behaves_like "an interruptible input plugin" do
-      let(:config) do
-        {
-          'consumer_key' => 'foo',
-          'consumer_secret' => 'foo',
-          'oauth_token' => 'foo',
-          'oauth_token_secret' => 'foo',
-          'keywords' => ['foo', 'bar']
-        }
+    let(:config) do
+      {
+        'consumer_key' => 'foo',
+        'consumer_secret' => 'foo',
+        'oauth_token' => 'foo',
+        'oauth_token_secret' => 'foo',
+        'keywords' => ['foo', 'bar']
+      }
+    end
+
+    context "registration" do
+      it "not raise error" do
+        input = LogStash::Plugin.lookup("input", "twitter").new(config)
+        expect {input.register}.to_not raise_error
       end
     end
+
+
+    it_behaves_like "an interruptible input plugin"
   end
 end

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -1,10 +1,52 @@
 require_relative "../spec_helper"
 
 describe LogStash::Inputs::Twitter do
+
+  let(:mock_client) { MockClient.new }
+
+  before :each do
+    allow(Twitter::Streaming::Client).to receive(:new).and_return(mock_client)
+  end
+
+  let(:input) { LogStash::Plugin.lookup("input", "twitter").new(config) }
+
+  let(:config) do
+    {
+      'consumer_key' => 'foo',
+      'consumer_secret' => 'foo',
+      'oauth_token' => 'foo',
+      'oauth_token_secret' => 'foo',
+      'keywords' => ['foo', 'bar']
+    }
+  end
+
   context "when told to shutdown" do
-    before :each do
-      allow(Twitter::Streaming::Client).to receive(:new).and_return(MockClient.new)
+    it_behaves_like "an interruptible input plugin"
+  end
+
+  context "registration" do
+
+    it "not raise error" do
+      expect {input.register}.to_not raise_error
     end
+
+    context "with no required configuration fields" do
+      let(:config) do
+        {
+          'consumer_key' => 'foo',
+          'consumer_secret' => 'foo',
+          'oauth_token' => 'foo',
+          'oauth_token_secret' => 'foo',
+        }
+      end
+
+      it "raise an error if no required fields are specified" do
+        expect {input.register}.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+  end
+
+  context "stream filter" do
 
     let(:config) do
       {
@@ -12,18 +54,77 @@ describe LogStash::Inputs::Twitter do
         'consumer_secret' => 'foo',
         'oauth_token' => 'foo',
         'oauth_token_secret' => 'foo',
-        'keywords' => ['foo', 'bar']
+        'keywords' => ['foo'],
+        'languages' => ['en', 'fr'],
+        'locations' => "1234,2343",
+        'follows' => [ '1234', '4321' ]
       }
     end
 
-    context "registration" do
-      it "not raise error" do
-        input = LogStash::Plugin.lookup("input", "twitter").new(config)
-        expect {input.register}.to_not raise_error
-      end
+    before(:each) do
+      input.register
     end
 
+    let(:options) { input.twitter_options }
 
-    it_behaves_like "an interruptible input plugin"
+    it "include the track filter in options" do
+      expect(options).to include(:track=>"foo")
+    end
+
+    it "include the language filter in options" do
+      expect(options).to include(:language=>"en,fr")
+    end
+
+    it "include the locations filter in options" do
+      expect(options).to include(:locations=>"1234,2343")
+    end
+
+     it "include the follows filter in options" do
+      expect(options).to include(:follow=>"1234,4321")
+    end
+
+     describe "run" do
+
+       let(:queue) { Queue.new }
+
+       before(:each) do
+         input.register
+       end
+
+       let(:options) do
+         {:track=>"foo", :locations=>"1234,2343", :language=>"en,fr", :follow=>"1234,4321"}
+       end
+
+       it "using the filter endpoint" do
+         expect(mock_client).to receive(:filter).with(options).once
+         Thread.new do
+           input.run(queue)
+         end
+         sleep 0.1
+       end
+
+       context "#sample" do
+         let(:config) do
+           {
+             'consumer_key' => 'foo',
+             'consumer_secret' => 'foo',
+             'oauth_token' => 'foo',
+             'oauth_token_secret' => 'foo',
+             'use_samples' => true
+           }
+         end
+
+         it "using the sample endpoint" do
+           expect(mock_client).to receive(:sample).once
+           Thread.new do
+             input.run(queue)
+           end
+           sleep 0.1
+         end
+
+       end
+     end
+
   end
+
 end

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -31,7 +31,7 @@ describe LogStash::Inputs::Twitter do
       end
     end
 
-    context "folling a user stream" do
+    context "pulling from sample" do
       let(:config) do
         <<-CONFIG
        input {
@@ -40,7 +40,7 @@ describe LogStash::Inputs::Twitter do
             consumer_secret => '#{ENV['TWITTER_CONSUMER_SECRET']}'
             oauth_token => '#{ENV['TWITTER_OAUTH_TOKEN']}'
             oauth_token_secret => '#{ENV['TWITTER_OAUTH_TOKEN_SECRET']}'
-            follows => '#{ENV['TWITTER_FOLLOW']}'
+            use_samples => true
         }
       }
         CONFIG
@@ -48,12 +48,12 @@ describe LogStash::Inputs::Twitter do
 
       let(:events) do
         input(config) do |pipeline, queue|
-          1.times.collect { queue.pop }
+          3.times.collect { queue.pop }
         end
       end
 
       it "receive a list of events from the twitter stream" do
-        expect(events.count).to eq(1)
+        expect(events.count).to eq(3)
       end
     end
 

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -1,0 +1,33 @@
+require_relative "../spec_helper"
+
+describe LogStash::Inputs::Twitter do
+
+  describe "#receive", :integration => true do
+
+    let(:config) do
+      <<-CONFIG
+       input {
+         twitter {
+            consumer_key => '#{ENV['TWITTER_CONSUMER_KEY']}'
+            consumer_secret => '#{ENV['TWITTER_CONSUMER_SECRET']}'
+            keywords => [ "London", "Barcelona" ]
+            oauth_token => '#{ENV['TWITTER_OAUTH_TOKEN']}'
+            oauth_token_secret => '#{ENV['TWITTER_OAUTH_TOKEN_SECRET']}'
+            full_tweet => true
+        }
+      }
+      CONFIG
+    end
+
+    let(:events) do
+      input(config) do |pipeline, queue|
+        3.times.collect { queue.pop }
+      end
+    end
+
+    it "receive a list of events from the twitter stream" do
+      expect(events.count).to eq(3)
+    end
+  end
+
+end

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -62,13 +62,13 @@ describe LogStash::Inputs::Twitter do
         expect(event["hashtags"]).to be_truthy
       end
 
-       it "contains the symbols" do
+      it "contains the symbols" do
         expect(event["symbols"]).to be_truthy
       end
 
-       it "contains the user_mentions" do
-         expect(event["user_mentions"]).to be_truthy
-       end
+      it "contains the user_mentions" do
+        expect(event["user_mentions"]).to be_truthy
+      end
 
     end
   end

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -4,8 +4,9 @@ describe LogStash::Inputs::Twitter do
 
   describe "#receive", :integration => true do
 
-    let(:config) do
-      <<-CONFIG
+    context "keyword search" do
+      let(:config) do
+        <<-CONFIG
        input {
          twitter {
             consumer_key => '#{ENV['TWITTER_CONSUMER_KEY']}'
@@ -16,18 +17,45 @@ describe LogStash::Inputs::Twitter do
             full_tweet => true
         }
       }
-      CONFIG
-    end
+        CONFIG
+      end
 
-    let(:events) do
-      input(config) do |pipeline, queue|
-        3.times.collect { queue.pop }
+      let(:events) do
+        input(config) do |pipeline, queue|
+          3.times.collect { queue.pop }
+        end
+      end
+
+      it "receive a list of events from the twitter stream" do
+        expect(events.count).to eq(3)
       end
     end
 
-    it "receive a list of events from the twitter stream" do
-      expect(events.count).to eq(3)
-    end
-  end
+    context "folling a user stream" do
+      let(:config) do
+        <<-CONFIG
+       input {
+         twitter {
+            consumer_key => '#{ENV['TWITTER_CONSUMER_KEY']}'
+            consumer_secret => '#{ENV['TWITTER_CONSUMER_SECRET']}'
+            oauth_token => '#{ENV['TWITTER_OAUTH_TOKEN']}'
+            oauth_token_secret => '#{ENV['TWITTER_OAUTH_TOKEN_SECRET']}'
+            follows => '#{ENV['TWITTER_FOLLOW']}'
+        }
+      }
+        CONFIG
+      end
 
+      let(:events) do
+        input(config) do |pipeline, queue|
+          1.times.collect { queue.pop }
+        end
+      end
+
+      it "receive a list of events from the twitter stream" do
+        expect(events.count).to eq(1)
+      end
+    end
+
+  end
 end

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -10,9 +10,9 @@ describe LogStash::Inputs::Twitter do
          twitter {
             consumer_key => '#{ENV['TWITTER_CONSUMER_KEY']}'
             consumer_secret => '#{ENV['TWITTER_CONSUMER_SECRET']}'
-            keywords => [ "London", "Barcelona" ]
             oauth_token => '#{ENV['TWITTER_OAUTH_TOKEN']}'
             oauth_token_secret => '#{ENV['TWITTER_OAUTH_TOKEN_SECRET']}'
+            keywords => [ 'Barcelona' ]
             full_tweet => true
         }
       }

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -52,10 +52,24 @@ describe LogStash::Inputs::Twitter do
         end
       end
 
+      let(:event) { events.first }
+
       it "receive a list of events from the twitter stream" do
         expect(events.count).to eq(3)
       end
-    end
 
+      it "contains the hashtags" do
+        expect(event["hashtags"]).to be_truthy
+      end
+
+       it "contains the symbols" do
+        expect(event["symbols"]).to be_truthy
+      end
+
+       it "contains the user_mentions" do
+         expect(event["user_mentions"]).to be_truthy
+       end
+
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,6 @@ class MockClient
   def filter(options)
     loop { yield }
   end
+
+  alias_method :sample, :filter
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,11 @@ class MockClient
 
   alias_method :sample, :filter
 end
+
+def run_input_with(input, queue)
+  t = Thread.new(input, queue) do |_input, _queue|
+    _input.run(_queue)
+  end
+  sleep 0.1
+  t.kill
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,9 @@
+require "logstash/devutils/rspec/spec_helper"
+require 'logstash/inputs/twitter'
+require 'twitter'
+
+class MockClient
+  def filter(options)
+    loop { yield }
+  end
+end


### PR DESCRIPTION
In this PR we added some features to this plugin:

* Add an option to fetch data from the sample endpoint.
* Add hashtags, symbols and user_mentions as data for the non extended tweet event.
* Add an option to filter per location and language.
* Add an option to stream data from a list of users.
* Add integration and unit tests for this and previous features.
* Add an ignore_retweet flag to filter them.

I also cleanup some code parts while organizing the code.

Fixes #22 #21 #20 #11 #9 

Incorporates some parts of #23