### PR TITLE
Add authentication to proxy support

### DIFF
--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -216,8 +216,8 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
         proxy_address: @proxy_address,
         proxy_port: @proxy_port
       }
-      c.proxy[:proxy_username] = @proxy_username if @proxy_username
-      c.proxy[:proxy_password] = @proxy_password if @proxy_password
+      c.proxy[:proxy_username] = @proxy_username       if @proxy_username
+      c.proxy[:proxy_password] = @proxy_password.value if @proxy_password
     end
   end
 

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -98,6 +98,12 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   # Port where the proxy is listening, by default 3128 (squid)
   config :proxy_port, :validate => :number, :default => 3128
 
+  # Proxy username to be used when performing authentication
+  config :proxy_username, :validate => :string
+
+  # Proxy password to be used when authenticating
+  config :proxy_password, :validate => :password
+
   def register
     require "twitter"
 
@@ -208,8 +214,10 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     if @use_proxy
       c.proxy =  {
         proxy_address: @proxy_address,
-        proxy_port: @proxy_port,
+        proxy_port: @proxy_port
       }
+      c.proxy[:proxy_username] = @proxy_username if @proxy_username
+      c.proxy[:proxy_password] = @proxy_password if @proxy_password
     end
   end
 


### PR DESCRIPTION
Fixes #32 providing authentication values as username and password. This PR need manual validation as the last one through for example a sample squid installation.