### PR TITLE
pin version of http-form_data to ruby 1.9 compatible version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.0.4
+ - Pin version of http-form_data to 1.0.1 since 1.0.2 isn't compatible with Ruby 1.9
+
 ## 3.0.3
   - Add protection for the (Java) Event when adding Twitter gem objects to the event in values,
     fixes #40.

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-twitter'
-  s.version         = '3.0.3'
+  s.version         = '3.0.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read events from the twitter streaming api."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'twitter', '5.15.0'
+  s.add_runtime_dependency 'http-form_data', '= 1.0.1'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
fixes https://github.com/elastic/logstash/issues/7044