### PR TITLE
add more restrictions due to Ruby 1.9 compatibility

### DIFF
--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -22,7 +22,8 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'twitter', '5.15.0'
-  s.add_runtime_dependency 'http-form_data', '= 1.0.1'
+  s.add_runtime_dependency 'http-form_data', '<= 1.0.1'
+  s.add_runtime_dependency 'public_suffix', '<= 1.4.6'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'
 
   s.add_development_dependency 'logstash-devutils'


### PR DESCRIPTION
the public_suffix gem (from: twitter -> http -> addressable -> public_suffix), must be pinned to `<= 1.4.6`, as more recent versions don't work with Ruby 1.9

also I relaxed the constraints on http-form_data so it's possible to install older versions.

error:
```
Gem::InstallError: public_suffix requires Ruby version >= 2.0.
An error occurred while installing public_suffix (2.0.5), and
Bundler cannot continue.
Make sure that `gem install public_suffix -v '2.0.5'` succeeds before
bundling.
```