### PR TITLE
return a userid instead of the Twitter::User object

### DIFF
--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -245,7 +245,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   end
 
   def find_user(username)
-    @rest_client.user(:user => username)
+    @rest_client.user(:user => username).id.to_i
   end
 
   def is_number?(string)


### PR DESCRIPTION
as per the documentation - follows should be a comma separated list of User IDs, however there appears to be logic that handles getting based a list of usernames instead via the `find_user` function.  However, this function returned an instance of the Twitter::User object  instead of the user_id of the user. 

This PR changes the behavior from returning a Twitter::User object to returning the user_id.

Thanks for contributing to Logstash! If you haven't already signed our CLA, here's a handy link: https://www.elastic.co/contributor-agreement/
