### PR TITLE
Update twitter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ addons:
     - docker-ce
 matrix:
   include:
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
-  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
   - env: ELASTIC_STACK_VERSION=7.x
   - env: ELASTIC_STACK_VERSION=6.x
+  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=7.x
+  - env: SNAPSHOT=true ELASTIC_STACK_VERSION=8.x
   fast_finish: true
 install: ci/unit/docker-setup.sh
 script: ci/unit/docker-run.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.1
+  - Updated Twitter gem to v6.2.0, cleaned up obsolete monkey patches, fixed integration tests [#63](https://github.com/logstash-plugins/logstash-input-twitter/pull/63)
+
 ## 4.0.0
   - Update http-form_data to ~> 2 and public_suffix to ~> 3
 

--- a/ci/unit/docker-setup.sh
+++ b/ci/unit/docker-setup.sh
@@ -1,51 +1,55 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is intended to be run the plugin's root directory. `ci/unit/docker-test.sh`
 # Ensure you have Docker installed locally and set the ELASTIC_STACK_VERSION environment variable.
 set -e
 
-VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/master/ci/logstash_releases.json"
+ VERSION_URL="https://raw.githubusercontent.com/elastic/logstash/master/ci/logstash_releases.json"
 
-if [ "$ELASTIC_STACK_VERSION" ]; then
-    echo "Fetching versions from $VERSION_URL"
-    VERSIONS=$(curl $VERSION_URL)
-    if [[ "$SNAPSHOT" = "true" ]]; then
-      ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
-      echo $ELASTIC_STACK_RETRIEVED_VERSION
-    else
-      ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.releases."'"$ELASTIC_STACK_VERSION"'"')
-    fi
-    if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
-      # remove starting and trailing double quotes
-      ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION%\"}"
-      ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION#\"}"
-      echo "Translated $ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
-      export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
-    fi
-
-    echo "Testing against version: $ELASTIC_STACK_VERSION"
-
-    if [[ "$ELASTIC_STACK_VERSION" = *"-SNAPSHOT" ]]; then
-        cd /tmp
-        wget https://snapshots.elastic.co/docker/logstash-"$ELASTIC_STACK_VERSION".tar.gz
-        tar xfvz logstash-"$ELASTIC_STACK_VERSION".tar.gz  repositories
-        echo "Loading docker image: "
-        cat repositories
-        docker load < logstash-"$ELASTIC_STACK_VERSION".tar.gz
-        rm logstash-"$ELASTIC_STACK_VERSION".tar.gz
-        cd -
-    fi
-
-    if [ -f Gemfile.lock ]; then
-        rm Gemfile.lock
-    fi
-
-    docker-compose -f ci/unit/docker-compose.yml down
-    docker-compose -f ci/unit/docker-compose.yml build
-    #docker-compose -f ci/unit/docker-compose.yml up --exit-code-from logstash --force-recreate
-else
+ if [ -z "${ELASTIC_STACK_VERSION}" ]; then
     echo "Please set the ELASTIC_STACK_VERSION environment variable"
     echo "For example: export ELASTIC_STACK_VERSION=6.2.4"
     exit 1
 fi
 
+ echo "Fetching versions from $VERSION_URL"
+VERSIONS=$(curl $VERSION_URL)
+
+ if [[ "$SNAPSHOT" = "true" ]]; then
+  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.snapshots."'"$ELASTIC_STACK_VERSION"'"')
+  echo $ELASTIC_STACK_RETRIEVED_VERSION
+else
+  ELASTIC_STACK_RETRIEVED_VERSION=$(echo $VERSIONS | jq '.releases."'"$ELASTIC_STACK_VERSION"'"')
+fi
+
+ if [[ "$ELASTIC_STACK_RETRIEVED_VERSION" != "null" ]]; then
+  # remove starting and trailing double quotes
+  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION%\"}"
+  ELASTIC_STACK_RETRIEVED_VERSION="${ELASTIC_STACK_RETRIEVED_VERSION#\"}"
+  echo "Translated $ELASTIC_STACK_VERSION to ${ELASTIC_STACK_RETRIEVED_VERSION}"
+  export ELASTIC_STACK_VERSION=$ELASTIC_STACK_RETRIEVED_VERSION
+fi
+
+ echo "Testing against version: $ELASTIC_STACK_VERSION"
+
+ if [[ "$ELASTIC_STACK_VERSION" = *"-SNAPSHOT" ]]; then
+    cd /tmp
+
+    jq=".build.projects.logstash.packages.\"logstash-$ELASTIC_STACK_VERSION-docker-image.tar.gz\".url"
+    result=$(curl --silent https://artifacts-api.elastic.co/v1/versions/$ELASTIC_STACK_VERSION/builds/latest | jq -r $jq)
+    echo $result
+    curl $result > logstash-docker-image.tar.gz
+    tar xfvz logstash-docker-image.tar.gz  repositories
+    echo "Loading docker image: "
+    cat repositories
+    docker load < logstash-docker-image.tar.gz
+    rm logstash-docker-image.tar.gz
+    cd -
+fi
+
+ if [ -f Gemfile.lock ]; then
+    rm Gemfile.lock
+fi
+
+docker-compose -f ci/unit/docker-compose.yml down
+docker-compose -f ci/unit/docker-compose.yml build

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -5,6 +5,7 @@ require "logstash/timestamp"
 require "logstash/util"
 require "logstash/json"
 require "stud/interval"
+require "twitter"
 require "logstash/inputs/twitter/patches"
 
 # Ingest events from the Twitter Streaming API.
@@ -104,8 +105,6 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
   config :rate_limit_reset_in, :validate => :number, :default => 300
 
   def register
-    require "twitter"
-
     if !@use_samples && ( @keywords.nil? && @follows.nil? && @locations.nil? )
       raise LogStash::ConfigurationError.new("At least one parameter (follows, locations or keywords) must be specified.")
     end

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -1,7 +1,5 @@
 # encoding: utf-8
-require 'twitter/streaming/connection'
 require 'twitter/streaming/response'
-require 'twitter/streaming/message_parser'
 
 module LogStash
   module Inputs
@@ -10,54 +8,12 @@ module LogStash
       def self.patch
         verify_version
         patch_json
-        patch_connection_stream
-        patch_request
       end
 
       private
 
       def self.verify_version
-        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "5.15.0"
-      end
-
-      def self.patch_connection_stream
-        ::Twitter::Streaming::Connection.class_eval do
-          def stream(request, response)
-            socket = @tcp_socket_class.new(Resolv.getaddress(request.socket_host), request.socket_port)
-            socket = ssl_stream(socket) if !request.using_proxy?
-
-            request.stream(socket)
-            while body = socket.readpartial(1024) # rubocop:disable AssignmentInCondition
-              response << body
-            end
-          end
-
-          def ssl_stream(client)
-            client_context = OpenSSL::SSL::SSLContext.new
-            ssl_client     = @ssl_socket_class.new(client, client_context)
-            ssl_client.connect
-          end
-
-          def normalized_port(scheme)
-            HTTP::URI.port_mapping[scheme]
-          end
-        end
-      end
-
-      def self.patch_request
-        ::Twitter::Streaming::Client.class_eval do
-          def request(method, uri, params)
-            before_request.call
-            headers = ::Twitter::Headers.new(self, method, uri, params).request_headers
-            request = ::HTTP::Request.new(method, uri + '?' + to_url_params(params), headers, proxy)
-            response = ::Twitter::Streaming::Response.new do |data|
-              if item = ::Twitter::Streaming::MessageParser.parse(data) # rubocop:disable AssignmentInCondition
-                yield(item)
-              end
-            end
-            @connection.stream(request, response)
-          end
-        end
+        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "6.2.0"
       end
 
       def self.patch_json

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-twitter'
-  s.version         = '4.0.0'
+  s.version         = '4.0.1'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the Twitter Streaming API"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -19,6 +19,10 @@ Gem::Specification.new do |s|
   # Special flag to let us know this is actually a logstash plugin
   s.metadata = { "logstash_plugin" => "true", "logstash_group" => "input" }
 
+  # public_suffix 3.x+ includes ruby syntax from 2.1
+  # This effectively requires Logstash >= 6.x
+  s.required_ruby_version = '>= 2.1.0'
+
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'twitter', '6.2.0'

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'twitter', '5.15.0'
+  s.add_runtime_dependency 'twitter', '6.2.0'
   s.add_runtime_dependency 'http-form_data', '~> 2'
   s.add_runtime_dependency 'public_suffix', '~> 3'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'

--- a/spec/integration/twitter_pubsub_spec.rb
+++ b/spec/integration/twitter_pubsub_spec.rb
@@ -45,7 +45,7 @@ describe LogStash::Inputs::Twitter do
         RSpec::Sequencing.run_after(1, "update tweet status") do
           twt = "logstash_ci_publish partial tweet test #{Time.now} #{SecureRandom.hex(6)} $AAPL #lscipub @logstash https://www.elastic.co/downloads/logstash"
           publisher.update_with_media(twt, File.open(LogstashTwitterInput.fixture("small_smile.png")))
-        end.then_after(3, "stop plugin") do
+        end.then_after(10, "stop plugin") do
           plugin.stop
           true
         end.value
@@ -64,10 +64,10 @@ describe LogStash::Inputs::Twitter do
       let(:full_tweets) { true }
 
       it "receives an event from the twitter stream" do
-        RSpec::Sequencing.run_after(0.1, "update tweet status") do
+        RSpec::Sequencing.run_after(1, "update tweet status") do
           twt = "logstash_ci_publish full tweet test #{Time.now} #{SecureRandom.hex(6)} $AAPL #lscipub @logstash https://www.elastic.co/downloads/logstash"
           publisher.update_with_media(twt, File.open(LogstashTwitterInput.fixture("small_smile.png")))
-        end.then_after(3, "stop plugin") do
+        end.then_after(10, "stop plugin") do
           plugin.stop
           true
         end.value


### PR DESCRIPTION
Update to twitter gem v6.2.0 which allow removing 2 obsolete monkey-patches.
This gem update removes the dependency on the faraday gem which has a version conflict per  elastic/logstash/pull/10934 
Integration tests delays have been also increased.
