### PR TITLE
Fixing proxy settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+  - Updated Twitter gem to v7.0.0
+  - Fixed up proxy from host/pass to uri so that it works.
 ## 4.0.1
   - Updated Twitter gem to v6.2.0, cleaned up obsolete monkey patches, fixed integration tests [#63](https://github.com/logstash-plugins/logstash-input-twitter/pull/63)
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,6 +4,7 @@ reports, or in general have helped logstash along its way.
 Contributors:
 * Bernd Ahlers (bernd)
 * Colin Surprenant (colinsurprenant)
+* Dan Major (axrayn)
 * Guy Boertje (guyboertje)
 * John E. Vincent (lusis)
 * Jordan Sissel (jordansissel)

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -41,6 +41,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-locations>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-oauth_token>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-oauth_token_secret>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-proxy_protocol>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_address>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-proxy_port>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-rate_limit_reset_in>> |<<number,number>>|No
@@ -175,6 +176,14 @@ Click on your app (used with the consumer_key and consumer_secret settings)
 Then at the bottom of the page, click 'Create my access token' which
 will create an oauth token and secret bound to your account and that
 application.
+
+[id="plugins-{type}s-{plugin}-proxy_protocol"]
+===== `proxy_protocol` 
+
+  * Value type is <<string,string>>
+  * Default value is `"http"`
+
+Protocol of the proxy, by default 'http'. Can be one of 'http' or 'https'.
 
 [id="plugins-{type}s-{plugin}-proxy_address"]
 ===== `proxy_address` 

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -113,7 +113,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     end
 
     if @use_proxy
-      if (@proxy_protocol.downcase != "http") || (@proxy_protocol.downcase != "https")
+      if (@proxy_protocol.downcase != "http") && (@proxy_protocol.downcase != "https")
         raise LogStash::ConfigurationError.new("Proxy protocol must be set to either http or https.")
       end
     end

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -234,7 +234,6 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
       c.proxy =  {
         uri: @proxy_protocol+"://"+@proxy_address+":"+@proxy_port.to_s
       }
-      @logger.info("Setting proxy to: ", c.proxy)
     end
   end
 

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -13,7 +13,7 @@ module LogStash
       private
 
       def self.verify_version
-        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "7.0.0"
+        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "6.2.0"
       end
 
       def self.patch_json

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -13,7 +13,7 @@ module LogStash
       private
 
       def self.verify_version
-        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "6.2.0"
+        raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "7.0.0"
       end
 
       def self.patch_json

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-twitter'
-  s.version         = '4.0.1'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the Twitter Streaming API"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'twitter', '6.2.0'
+  s.add_runtime_dependency 'twitter', '7.0.0'
   s.add_runtime_dependency 'http-form_data', '~> 2'
   s.add_runtime_dependency 'public_suffix', '~> 3'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
-  s.add_runtime_dependency 'twitter', '7.0.0'
+  s.add_runtime_dependency 'twitter', '6.2.0'
   s.add_runtime_dependency 'http-form_data', '~> 2'
   s.add_runtime_dependency 'public_suffix', '~> 3'
   s.add_runtime_dependency 'stud', '>= 0.0.22', '< 0.1'

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -35,6 +35,19 @@ describe LogStash::Inputs::Twitter do
         expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
       end
     end
+
+    context "with unsupported proxy protocol" do
+      let(:config) do
+        {
+          'use_proxy' => true,
+          'proxy_protocol' => "SOCKS",
+        }
+      end
+
+      it "raise an error if unsupported proxy protocol specified" do
+        expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
+      end
+    end
   end
 
   describe "when told to shutdown" do


### PR DESCRIPTION
After having issues with the plugin not connecting through our proxy under Logstash 7.6.2, I worked out that the Twitter gem requires the proxy to be passed as a URI and not a host/port pair.

This PR adds the config param 'proxy_protocol' and updates the configure function to use the constructed 'uri' of "@proxy_protocol://@proxy_address:@proxy_port" instead of setting proxy_address and proxy_port keys.

Edit: Removed the Twitter gem update as it was causing dependency issues
