### PR TITLE
Fix: user rest api call + proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+  - Fix: user rest api call + proxy configuration [#68](https://github.com/logstash-plugins/logstash-input-twitter/pull/68)
+
 ## 4.0.1
   - Updated Twitter gem to v6.2.0, cleaned up obsolete monkey patches, fixed integration tests [#63](https://github.com/logstash-plugins/logstash-input-twitter/pull/63)
 

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -146,7 +146,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
       retry
     rescue => e
       # if a lot of these errors begin to occur, the repeated retry will result in TooManyRequests errors trapped above.
-      @logger.warn("Twitter client error", :message => e.message, :exception => e.class.name, :backtrace => e.backtrace, :options => @filter_options)
+      @logger.warn("Twitter client error", :message => e.message, :exception => e.class, :backtrace => e.backtrace, :options => @filter_options)
       retry
     end
   end # def run
@@ -173,7 +173,7 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
         queue << event
       rescue => e
         @event_generation_error_count = @event_generation_error_count.next
-        @logger.error("Event generation error", :message => e.message, :exception => e.class.name, :backtrace => e.backtrace.take(10))
+        @logger.error("Event generation error", :message => e.message, :exception => e.class, :backtrace => e.backtrace)
       end
     end
   end

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -236,15 +236,18 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     build_options[:language]  = @languages.join(",") if @languages && !@languages.empty?
 
     if @follows && @follows.length > 0
-      build_options[:follow]    = @follows.map do |username|
-        (  !is_number?(username) ? find_user(username) : username )
+      build_options[:follow] = @follows.map do |username|
+        is_number?(username) ? username : find_user_id(username).to_s
       end.join(",")
     end
     build_options
   end
 
-  def find_user(username)
-    @rest_client.user(:user => username)
+  # @return [Integer] user id
+  # @raise [Twitter::Error::NotFound]
+  def find_user_id(username)
+    @logger.debug? && @logger.debug("Looking up twitter user identifier for", :user => username)
+    @rest_client.user(:screen_name => username).id # Twitter::User#id
   end
 
   def is_number?(string)

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -216,16 +216,17 @@ class LogStash::Inputs::Twitter < LogStash::Inputs::Base
     event
   end
 
-  def configure(c)
-    c.consumer_key = @consumer_key
-    c.consumer_secret = @consumer_secret.value
-    c.access_token = @oauth_token
-    c.access_token_secret = @oauth_token_secret.value
+  def configure(client)
+    client.consumer_key = @consumer_key
+    client.consumer_secret = @consumer_secret.value
+    client.access_token = @oauth_token
+    client.access_token_secret = @oauth_token_secret.value
     if @use_proxy
-      c.proxy =  {
-        proxy_address: @proxy_address,
-        proxy_port: @proxy_port,
-      }
+      if client.is_a?(Twitter::REST::Client)
+        client.proxy = { host: @proxy_address, port: @proxy_port }
+      else
+        client.proxy = { proxy_address: @proxy_address, proxy_port: @proxy_port }
+      end
     end
   end
 

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-input-twitter'
-  s.version         = '4.0.1'
+  s.version         = '4.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the Twitter Streaming API"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -18,7 +18,7 @@ describe LogStash::Inputs::Twitter do
   describe "registration" do
 
     it "not raise error" do
-      expect {plugin.register}.to_not raise_error
+      expect { plugin.register }.to_not raise_error
     end
 
     context "with no required configuration fields" do
@@ -32,7 +32,30 @@ describe LogStash::Inputs::Twitter do
       end
 
       it "raise an error if no required fields are specified" do
-        expect {plugin.register}.to raise_error(LogStash::ConfigurationError)
+        expect { plugin.register }.to raise_error(LogStash::ConfigurationError)
+      end
+    end
+
+    context "with follows" do
+
+      let(:user) { Twitter::User.new(id: 11111111) }
+
+      let(:config) do
+        {
+            'consumer_key' => 'foo',
+            'consumer_secret' => 'foo',
+            'oauth_token' => 'foo',
+            'oauth_token_secret' => 'foo',
+            'keywords' => ['bar'],
+            'follows' => ['12345678', 'theborg']
+        }
+      end
+
+      it "looks up user name" do
+        allow_any_instance_of(Twitter::REST::Client).
+            to receive(:user).with(screen_name: 'theborg').and_return user
+        plugin.register
+        expect(plugin.send(:build_options)).to include(follow: '12345678,11111111')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,8 +26,7 @@ module LogstashTwitterInput
     t = Thread.new(input, queue) do |_input, _queue|
       _input.run(_queue)
     end
-    sleep 0.1
-    t.kill
+    t.kill unless t.join(1.5) # due CI
   end
 
   def self.fixture_path


### PR DESCRIPTION
The plugin is relying on a streaming client but for a minor feature we also use the rest client, that is when:
`follows => [ '12345678', 'elastic' ]` contains a twitter user handle instead of the (internal) user identifier,
the plugin will look up such user using the REST client.

The code path to do the lookup properly was broken (seems like a known issue https://github.com/logstash-plugins/logstash-input-twitter/pull/60). 
Also the proxy configuration is slightly different for the REST client (this seems like a bug and is reported upstream).
The setup was tested using twitter gem 6.2.0, behavior is the same in latest (7.0.0).

closes #60