### PR TITLE
Fix: broken proxy configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+ - Fix: broken proxy configuration [#69](https://github.com/logstash-plugins/logstash-input-twitter/pull/69)
+
 ## 4.0.2
 
   - Fix: user rest api call + proxy configuration [#68](https://github.com/logstash-plugins/logstash-input-twitter/pull/68)

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -8,6 +8,7 @@ module LogStash
       def self.patch
         verify_version
         patch_json
+        patch_http_request
       end
 
       private
@@ -27,6 +28,21 @@ module LogStash
                 # silently ignore json parsing errors
               end
             end
+          end
+        end
+      end
+
+      def self.patch_http_request
+        ::HTTP::Request.class_eval do
+          def headline
+            request_uri =
+                if using_proxy? #&& !uri.https?
+                  uri.omit(:fragment)
+                else
+                  uri.request_uri
+                end
+
+            "#{verb.to_s.upcase} #{request_uri} HTTP/#{version}"
           end
         end
       end

--- a/lib/logstash/inputs/twitter/patches.rb
+++ b/lib/logstash/inputs/twitter/patches.rb
@@ -15,10 +15,16 @@ module LogStash
 
       def self.verify_version
         raise("Incompatible Twitter gem version and the LogStash::Json.load") unless ::Twitter::Version.to_s == "6.2.0"
+        # NOTE: we're also known to work with twitter gem version 7.0 which uses http 4.x
+        raise("Incompatible HTTP gem version: #{HTTP::VERSION}") if HTTP::VERSION >= '5.0' || HTTP::VERSION < '3.0'
+        # after a major upgrade, unless CI is running integration specs, please run integration specs manually
       end
 
       def self.patch_json
         ::Twitter::Streaming::Response.module_eval do
+          unless method_defined? :on_body
+            raise "::Twitter::Streaming::Response#on_body not defined!" # patch bellow needs a review
+          end
           def on_body(data)
             @tokenizer.extract(data).each do |line|
               next if line.empty?
@@ -33,7 +39,13 @@ module LogStash
       end
 
       def self.patch_http_request
+        # NOTE: we might decide to drop the patch at some point, for now proxies such as squid
+        # are opinionated about having full URIs in the http head-line (having only /path fails
+        # with 400 Bad Request in Squid 4.10).
         ::HTTP::Request.class_eval do
+          unless method_defined? :headline
+            raise "::HTTP::Request#headline not defined!" # patch bellow needs a review
+          end
           def headline
             request_uri =
                 if using_proxy? #&& !uri.https?

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-twitter'
-  s.version         = '4.0.2'
+  s.version         = '4.0.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the Twitter Streaming API"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/integration/twitter_spec.rb
+++ b/spec/integration/twitter_spec.rb
@@ -5,6 +5,16 @@ require_relative "../spec_helper"
 
 describe LogStash::Inputs::Twitter do
 
+  let(:events) do
+    input(config) do |_, queue|
+      event_count.times.collect { queue.pop }
+    end
+  end
+
+  let(:event_count) { 3 }
+
+  let(:event) { events.first }
+
   describe "#receive [integration]", :integration => true do
 
     context "keyword search" do
@@ -21,12 +31,6 @@ describe LogStash::Inputs::Twitter do
         }
       }
         CONFIG
-      end
-
-      let(:events) do
-        input(config) do |pipeline, queue|
-          3.times.collect { queue.pop }
-        end
       end
 
       it "receive a list of events from the twitter stream" do
@@ -49,28 +53,14 @@ describe LogStash::Inputs::Twitter do
         CONFIG
       end
 
-      let(:events) do
-        input(config) do |pipeline, queue|
-          3.times.collect { queue.pop }
-        end
-      end
-
-      let(:event) { events.first }
-
       it "receive a list of events from the twitter stream" do
         expect(events.count).to eq(3)
-      end
 
-      it "contains the hashtags" do
-        expect(event["hashtags"]).to be_truthy
-      end
+        event.tap { |event| puts "sample event: #{event.to_hash}" } if $VERBOSE
 
-      it "contains the symbols" do
-        expect(event["symbols"]).to be_truthy
-      end
-
-      it "contains the user_mentions" do
-        expect(event["user_mentions"]).to be_truthy
+        expect(event.get("hashtags")).to be_truthy
+        expect(event.get("symbols")).to be_truthy
+        expect(event.get("user_mentions")).to be_truthy
       end
 
     end
@@ -88,20 +78,15 @@ describe LogStash::Inputs::Twitter do
             full_tweet => true
             use_proxy => true
             proxy_address => '127.0.0.1'
-            proxy_port => 8123
+            proxy_port => 3128
         }
       }
         CONFIG
       end
 
-      let(:events) do
-        input(config) do |pipeline, queue|
-          3.times.collect { queue.pop }
-        end
-      end
-
       it "receive a list of events from the twitter stream" do
         expect(events.count).to eq(3)
+        event.tap { |event| puts "sample event (using proxy): #{event.to_hash}" } if $VERBOSE
       end
     end
   end


### PR DESCRIPTION
using a proxy to connect to Twitter's *https://stream.twitter.com* is broken since **4.0.1**.

due the twitter gem [upgrade](https://github.com/logstash-plugins/logstash-input-twitter/commit/d4757f541d0d1669556a5f5e0db7791b2047174c#diff-0de54546d64dcd37882ea4b627facfbaR24) (in 4.0.1) the plugin ended up using [http.rb >= 2.0.0](https://rubygems.org/gems/twitter/versions/6.2.0) which contains a fix for strict proxies/servers to NOT send full request URIs in the header line. the only way to restore the 4.0.0 plugin's behaviour is by patching the http library.

"fortunately", only Twitter plugin seems to be using the gem. 


details at: https://github.com/logstash-plugins/logstash-input-twitter/issues/67#issuecomment-703597015
resolves #67