### PR TITLE
Feat: optional target + ecs_compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.1.0
+ - Feat: optional target + ecs_compatibility [#72](https://github.com/logstash-plugins/logstash-input-twitter/pull/72)
+
 ## 4.0.3
  - Fix: broken proxy configuration [#69](https://github.com/logstash-plugins/logstash-input-twitter/pull/69)
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,12 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Ingest events from the Twitter Streaming API.
 
+==== Compatibility with the Elastic Common Schema (ECS)
+
+Twitter streams are very specific and do not map easily to the {ecs-ref}[Elastic Common Schema (ECS)].
+We recommend setting a <<plugins-{type}s-{plugin}-target>> when <<plugins-{type}s-{plugin}-ecs_compatibility,ECS compatibility mode>> is enabled.
+The plugin issues a warning in the log when a `target` isn't set.
+
 [id="plugins-{type}s-{plugin}-options"]
 ==== Twitter Input Configuration Options
 
@@ -33,6 +39,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 |Setting |Input type|Required
 | <<plugins-{type}s-{plugin}-consumer_key>> |<<string,string>>|Yes
 | <<plugins-{type}s-{plugin}-consumer_secret>> |<<password,password>>|Yes
+| <<plugins-{type}s-{plugin}-ecs_compatibility>> |<<string,string>>|No
 | <<plugins-{type}s-{plugin}-follows>> |<<array,array>>|No
 | <<plugins-{type}s-{plugin}-full_tweet>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-ignore_retweets>> |<<boolean,boolean>>|No
@@ -46,6 +53,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-rate_limit_reset_in>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-use_proxy>> |<<boolean,boolean>>|No
 | <<plugins-{type}s-{plugin}-use_samples>> |<<boolean,boolean>>|No
+| <<plugins-{type}s-{plugin}-target>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -77,6 +85,19 @@ Your Twitter App's consumer secret
 If you don't have one of these, you can create one by
 registering a new application with Twitter:
 <https://dev.twitter.com/apps/new>
+
+[id="plugins-{type}s-{plugin}-ecs_compatibility"]
+===== `ecs_compatibility`
+
+  * Value type is <<string,string>>
+  * Supported values are:
+    ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+  * Default value depends on which version of Logstash is running:
+    ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
+    ** Otherwise, the default value is `disabled`.
+
+Controls this plugin's compatibility with the {ecs-ref}[Elastic Common Schema (ECS)].
 
 [id="plugins-{type}s-{plugin}-follows"]
 ===== `follows` 
@@ -220,6 +241,17 @@ Returns a small random sample of all public statuses. The tweets returned
 by the default access level are the same, so if two different clients connect
 to this endpoint, they will see the same tweets. If set to true, the keywords, 
 follows, locations, and languages options will be ignored. Default => false
+
+[id="plugins-{type}s-{plugin}-target"]
+===== `target`
+
+  * Value type is <<string,string>>
+  * There is no default value for this setting.
+
+Without a `target`, events are created from tweets at the root level.
+When the `target` is set to a field reference, the tweet data is placed in the target field instead.
+
+This option can be useful to avoid populating unknown fields when a downstream schema such as ECS is enforced.
 
 
 

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -56,6 +56,7 @@ Sample event fields generated:
     }
 -----
 
+[id="plugins-{type}s-{plugin}-ecs"]
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 Twitter streams are very specific and do not map easily to the {ecs-ref}[Elastic Common Schema (ECS)].

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -126,7 +126,7 @@ registering a new application with Twitter:
   * Value type is <<string,string>>
   * Supported values are:
     ** `disabled`: does not use ECS-compatible field names (fields might be set at the root of the event)
-    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, JMS specific properties)
+    ** `v1`, `v8`: avoids field names that might conflict with Elastic Common Schema (for example, Twitter specific properties)
   * Default value depends on which version of Logstash is running:
     ** When Logstash provides a `pipeline.ecs_compatibility` setting, its value is used as the default
     ** Otherwise, the default value is `disabled`.

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -23,6 +23,39 @@ include::{include_path}/plugin_header.asciidoc[]
 
 Ingest events from the Twitter Streaming API.
 
+Example:
+[source,ruby]
+    input {
+      twitter {
+        consumer_key => '...'
+        consumer_secret => '...'
+        oauth_token => '...'
+        oauth_token_secret => '...'
+        keywords => [ 'logstash' ]
+      }
+    }
+
+Sample event fields generated:
+
+[source,ruby]
+-----
+    {
+        "@timestamp" => 2019-09-23T16:41:53.000Z,
+        "message" => "I forgot how fun it is to write @logstash configs !!! Thank you @jordansissel and @elastic !!!"
+        "user" => "missnebun",
+        "in-reply-to" => nil,
+        "retweeted" => false,
+        "source" => "http://twitter.com/missnebun/status/1176174859833004037",
+        "user_mentions" => [
+            { "screen_name"=>"logstash", "name"=>"logstash", "id"=>217155915 },
+            { "screen_name"=>"jordansissel", "name"=>"@jordansissel", "id"=>15782607 },
+            { "screen_name"=>"elastic", "name"=>"Elastic", "id"=>84512601 }],
+        "symbols" => [],
+        "hashtags" => [],
+        "client" => "<a href=\"http://twitter.com/download/iphone\" rel=\"nofollow\">Twitter for iPhone</a>"
+    }
+-----
+
 ==== Compatibility with the Elastic Common Schema (ECS)
 
 Twitter streams are very specific and do not map easily to the {ecs-ref}[Elastic Common Schema (ECS)].

--- a/lib/logstash/inputs/twitter.rb
+++ b/lib/logstash/inputs/twitter.rb
@@ -16,6 +16,7 @@ require 'logstash/plugin_mixins/validator_support/field_reference_validation_ada
 class LogStash::Inputs::Twitter < LogStash::Inputs::Base
 
   include LogStash::PluginMixins::ECSCompatibilitySupport(:disabled, :v1, :v8 => :v1)
+  include LogStash::PluginMixins::ECSCompatibilitySupport::TargetCheck
   include LogStash::PluginMixins::EventSupport::EventFactoryAdapter
 
   extend LogStash::PluginMixins::ValidatorSupport::FieldReferenceValidationAdapter

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -24,6 +24,9 @@ Gem::Specification.new do |s|
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
+  s.add_runtime_dependency 'logstash-mixin-ecs_compatibility_support', '~> 1.3'
+  s.add_runtime_dependency "logstash-mixin-event_support", '~> 1.0'
+  s.add_runtime_dependency 'logstash-mixin-validator_support', '~> 1.0'
   s.add_runtime_dependency 'twitter', '6.2.0'
   s.add_runtime_dependency 'http-form_data', '~> 2'
   s.add_runtime_dependency 'public_suffix', '~> 3'

--- a/logstash-input-twitter.gemspec
+++ b/logstash-input-twitter.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-input-twitter'
-  s.version         = '4.0.3'
+  s.version         = '4.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events from the Twitter Streaming API"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -134,6 +134,19 @@ describe LogStash::Inputs::Twitter do
         expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
       end
     end
+
+    context 'with target' do
+      let(:config) { super().merge 'target' => '[twitter]' }
+
+      it "generated an event" do
+        expect(@event.include?('message')).to be false
+        expect(@event.include?('user')).to be false
+
+        expect(@event.get('[twitter][message]')).to eql "Hello World! 🥰"
+        expect(@event.get('[twitter][user]')).to eql "foo001"
+        expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+      end
+    end
   end
 
   describe "stream filter" do

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -122,7 +122,7 @@ describe LogStash::Inputs::Twitter do
     it "generated an event" do
       expect(@event.get('message')).to eql "Hello World! 🥰"
       expect(@event.get('user')).to eql "foo001"
-      expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+      expect(@event.timestamp.to_s).to match /2021-11-11T10:00:00(.000)?Z/
     end
 
     context 'with full_tweet' do
@@ -131,7 +131,7 @@ describe LogStash::Inputs::Twitter do
       it "generated an event" do
         expect(@event.get('text')).to eql "Hello World! 🥰"
         expect(@event.get('user')['screen_name']).to eql "foo001"
-        expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+        expect(@event.timestamp.to_s).to match /2021-11-11T10:00:00(.000)?Z/
       end
     end
 
@@ -144,7 +144,7 @@ describe LogStash::Inputs::Twitter do
 
         expect(@event.get('[twitter][message]')).to eql "Hello World! 🥰"
         expect(@event.get('[twitter][user]')).to eql "foo001"
-        expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+        expect(@event.timestamp.to_s).to match /2021-11-11T10:00:00(.000)?Z/
       end
     end
   end

--- a/spec/inputs/twitter_spec.rb
+++ b/spec/inputs/twitter_spec.rb
@@ -97,6 +97,45 @@ describe LogStash::Inputs::Twitter do
 
   end
 
+  let(:tweet) do
+    Twitter::Tweet.new(id: 1234567890123456789,
+                       id_str: '1234567890123456789',
+                       created_at: 'Thu Nov 11 10:00:00 +0000 2021',
+                       text: 'Hello World! 🥰',
+                       source: "<a href=\"http://twitter.com/download/android\" rel=\"nofollow\">Twitter for Android</a>",
+                       truncated: false,
+                       user: {
+                           id: 1182909005012345600,
+                           name: "Foo Bar",
+                           screen_name: "foo001",
+                           location: nil,
+                       })
+  end
+
+  describe "from tweet" do
+
+    before(:each) do
+      plugin.register
+      @event = plugin.send :from_tweet, tweet
+    end
+
+    it "generated an event" do
+      expect(@event.get('message')).to eql "Hello World! 🥰"
+      expect(@event.get('user')).to eql "foo001"
+      expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+    end
+
+    context 'with full_tweet' do
+      let(:config) { super().merge 'full_tweet' => true }
+
+      it "generated an event" do
+        expect(@event.get('text')).to eql "Hello World! 🥰"
+        expect(@event.get('user')['screen_name']).to eql "foo001"
+        expect(@event.timestamp.to_s).to eql '2021-11-11T10:00:00.000Z'
+      end
+    end
+  end
+
   describe "stream filter" do
 
     describe "options parsing" do
@@ -161,8 +200,6 @@ describe LogStash::Inputs::Twitter do
 
       context "when not filtering retweets" do
 
-        let(:tweet) { Twitter::Tweet.new(id: 1) }
-
         let(:config) do
           {
             'consumer_key' => 'foo',
@@ -186,8 +223,6 @@ describe LogStash::Inputs::Twitter do
       end
 
       context "when filtering retweets" do
-
-        let(:tweet) { Twitter::Tweet.new(id: 1) }
 
         let(:config) do
           {


### PR DESCRIPTION
Improve plugins ability to function in an environment where ECS is enabled.

We're adding an optional event `target` to place tweet information, this setting is recommended to be set the `ecs_compatibility` is enabled.

*Also added a sample, in the docs, on how a tweet actually looks like - so users can easily reason about fields they might want to extract/rename.*